### PR TITLE
Update Rubocop rules for Rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,518 @@
-inherit_gem:
-  rubocop-rails:
-    - config/rails.yml
+# Rails
+# =====
+#
+# Here are some additions to Scaffolint for Rails apps.
+#
+# Enable the Rails rules included in the rubocop-rails gem.
+require:
+  - rubocop-rails
 
+# Exclusions
+# ==========
+#
+# Rails has powerful generators.
+#
+# Some auto-generated files are edited frequently. We want to lint them,
+# so let's avoid adding them to this list.
+# e.g. controllers, models, views
+#
+# Other auto-generated files are usually not edited afterwards.
+# There's almost zero value in linting them, so let's exclude them.
+# e.g. binstubs, config, migrations
+
+AllCops:
+  Exclude:
+    - 'bin/*'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'vendor/**/*'
+
+#    _____               ____ ____        __     _         __
+#   / ___/ _____ ____ _ / __// __/____   / /    (_)____   / /_
+#   \__ \ / ___// __ `// /_ / /_ / __ \ / /    / // __ \ / __/
+#  ___/ // /__ / /_/ // __// __// /_/ // /___ / // / / // /_
+# /____/ \___/ \__,_//_/  /_/ 1 \____//_____//_//_/ /_/ \__/
+#
+# The linter file that doesn't lead junior developers to bad habits.
+# https://github.com/makersacademy/scaffolint
+#
+# Problems (eg obselete names) may be due to an incompatible version.
+# Check your Rubocop version with `rubocop -v` in the command line.
+#
+# Tested with Rubocop version 0.79.0
+#
+# Introduction
+# ============
+#
+# Our order of priorities:
+#
+#   1. Conforming your code to the styleguide.
+#   2. The styleguide being thorough and complete.
+#
+# This file relaxes Rubocop a bit so you can learn about code quality rather
+# than just following the rules. Some guidelines can result in worse code if you
+# don't know why they are there. For instance, if a line is too long, you might
+# be tempted to simply abbreviate your variable names - making your code harder
+# to read.
+#
+# We prioritize rules that offer good, easily incorporated feedback on improving
+# your code, without being overwhelming or requiring experienced judgement.
+#
+# As you become a better developer you will remove or amend this file according
+# to what you think good code should look like.
+#
+# Physical Code Size
+# ==================
+#
+# Sometimes beginner devs interpret line or block length restrictions as a
+# reason to make things so abbreviated as to be unreadable. These messages are
+# designed to make you write more readable code - not less.
+#
+# We want to encourage testing, but it can be verbose in the early stages.
+# So we'll give you a break. As you learn, try removing the next two sections.
+
+Layout/LineLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+  Max: 100
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+
+# Code Style
+# ==========
+#
+# Many devs, upon running a linter for the first time, see a big wall of errors
+# of dubious necessity and put it in the 'way too much trouble' box. Beginners
+# usually have far more pressing concerns than which sort of quotes they use.
+#
+# This makes Rubocop have a bigger 'payoff' for beginners without so much of
+# the punishment. We focus our linting on things that significantly impact
+# readability, expressiveness, or teach a dev new things. For example:
+#
+#   * Indentation & whitespace (inconsistency, really gross stuff like `a=1`)
+#   * Easy wins in expressiveness (e.g. guard clauses — nice opportunity to
+#     inject concretes)
+#   * Egregious non-idiomatic ruby like `def getFilename`
+
+Layout/IndentationConsistency:
+  Enabled: true
+Layout/IndentationWidth:
+  Enabled: true
+Naming/AccessorMethodName:
+  Enabled: true
+Layout/BlockEndNewline:
+  Enabled: true
+Style/DefWithParentheses:
+  Enabled: true
+Layout/EmptyLineBetweenDefs:
+  Enabled: true
+Layout/EmptyLines:
+  Enabled: true
+Layout/ExtraSpacing:
+  Enabled: true
+Style/GuardClause:
+  Enabled: true
+Style/IdenticalConditionalBranches:
+  Enabled: true
+Style/InverseMethods:
+  Enabled: true
+Layout/LeadingCommentSpace:
+  Enabled: true
+Style/NegatedIf:
+  Enabled: true
+Style/NegatedWhile:
+  Enabled: true
+Style/NilComparison:
+  Enabled: true
+Style/Not:
+  Enabled: true
+Style/NumericLiterals:
+  Enabled: true
+Style/NumericPredicate:
+  Enabled: true
+Style/OneLineConditional:
+  Enabled: true
+Style/RedundantParentheses:
+  Enabled: true
+Style/RedundantSelf:
+  Enabled: true
+Style/SafeNavigation:
+  Enabled: true
+Style/SelfAssignment:
+  Enabled: true
+Layout/SpaceAfterColon:
+  Enabled: true
+Layout/SpaceAfterComma:
+  Enabled: true
+Layout/SpaceAfterMethodName:
+  Enabled: true
+Layout/SpaceAfterNot:
+  Enabled: true
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+Layout/SpaceAroundBlockParameters:
+  Enabled: true
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+Layout/SpaceAroundKeyword:
+  Enabled: true
+Layout/SpaceAroundOperators:
+  Enabled: true
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+Layout/SpaceBeforeComma:
+  Enabled: true
+Layout/SpaceBeforeComment:
+  Enabled: true
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+Layout/SpaceInLambdaLiteral:
+  Enabled: true
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: true
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: true
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+Layout/SpaceInsideParens:
+  Enabled: true
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: true
+Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+Layout/SpaceInsideStringInterpolation:
+  Enabled: true
+Style/SymbolLiteral:
+  Enabled: true
+Layout/TrailingEmptyLines:
+  Enabled: true
+Style/TrivialAccessors:
+  Enabled: true
+
+# Rubocop doesn't make disabling all cops in a given group easy, so we list...
+Layout/AccessModifierIndentation:
+  Enabled: false
+Style/Alias:
+  Enabled: false
+Layout/ArrayAlignment:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+Layout/ParameterAlignment:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/ArrayJoin:
+  Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Naming/AsciiIdentifiers:
+  Enabled: false
+Style/Attr:
+  Enabled: false
+Style/AutoResourceCleanup:
+  Enabled: false
+Style/BarePercentLiterals:
+  Enabled: false
+Style/BeginBlock:
+  Enabled: false
+Style/BlockComments:
+  Enabled: false
+Style/BlockDelimiters:
+  Enabled: false
+Style/BracesAroundHashParameters:
+  Enabled: false
+Style/CaseEquality:
+  Enabled: false
+Layout/CaseIndentation:
+  Enabled: false
+Style/CharacterLiteral:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/ClassCheck:
+  Enabled: false
+Style/ClassMethods:
+  Enabled: false
+Style/ClassVars:
+  Enabled: false
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+Style/CollectionMethods:
+  Enabled: false
+Style/ColonMethodCall:
+  Enabled: false
+Style/CommandLiteral:
+  Enabled: false
+Style/CommentAnnotation:
+  Enabled: false
+Layout/CommentIndentation:
+  Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/Copyright:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/DocumentationMethod:
+  Enabled: false
+Layout/DotPosition:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/EachForSimpleLoop:
+  Enabled: false
+Style/EachWithObject:
+  Enabled: false
+Layout/ElseAlignment:
+  Enabled: false
+Style/EmptyCaseCondition:
+  Enabled: false
+Style/EmptyElse:
+  Enabled: false
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: false
+Layout/EmptyLinesAroundBeginBody:
+  Enabled: false
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: false
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: false
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+Style/EmptyLiteral:
+  Enabled: false
+Style/EmptyMethod:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/EndBlock:
+  Enabled: false
+Layout/EndOfLine:
+  Enabled: false
+Style/EvenOdd:
+  Enabled: false
+Layout/FirstArrayElementLineBreak:
+  Enabled: false
+Layout/FirstHashElementLineBreak:
+  Enabled: false
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: false
+Layout/FirstMethodParameterLineBreak:
+  Enabled: false
+Layout/FirstArgumentIndentation:
+  Enabled: false
+Lint/FlipFlop:
+  Enabled: false
+Style/For:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalVars:
+  Enabled: false
+Style/HashSyntax:
+  Enabled: false
+Style/IfInsideElse:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+Style/IfWithSemicolon:
+  Enabled: false
+Style/ImplicitRuntimeError:
+  Enabled: false
+Layout/FirstArrayElementIndentation:
+  Enabled: false
+Layout/AssignmentIndentation:
+  Enabled: false
+Layout/FirstHashElementIndentation:
+  Enabled: false
+Layout/HeredocIndentation:
+  Enabled: false
+Style/InfiniteLoop:
+  Enabled: false
+Layout/InitialIndentation:
+  Enabled: false
+Style/InlineComment:
+  Enabled: false
+Style/Lambda:
+  Enabled: false
+Style/LambdaCall:
+  Enabled: false
+Style/LineEndConcatenation:
+  Enabled: false
+Style/MethodCallWithArgsParentheses:
+  Enabled: false
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: false
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MethodDefParentheses:
+  Enabled: false
+Style/MethodMissingSuper:
+  Enabled: false
+Style/MissingRespondToMissing:
+  Enabled: false
+Style/MissingElse:
+  Enabled: false
+Style/MixinGrouping:
+  Enabled: false
+Style/ModuleFunction:
+  Enabled: false
+Layout/MultilineArrayBraceLayout:
+  Enabled: false
+Layout/MultilineAssignmentLayout:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Layout/MultilineBlockLayout:
+  Enabled: false
+Layout/MultilineHashBraceLayout:
+  Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false
+Style/MultilineIfThen:
+  Enabled: false
+Style/MultilineMemoization:
+  Enabled: false
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+Layout/MultilineMethodDefinitionBraceLayout:
+  Enabled: false
+Layout/MultilineOperationIndentation:
+  Enabled: false
+Style/MultilineTernaryOperator:
+  Enabled: false
+Style/MutableConstant:
+  Enabled: false
+Style/NestedModifier:
+  Enabled: false
+Style/NestedParenthesizedCalls:
+  Enabled: false
+Style/NestedTernaryOperator:
+  Enabled: false
+Style/Next:
+  Enabled: false
+Style/NonNilCheck:
+  Enabled: false
+Style/NumericLiteralPrefix:
+  Enabled: false
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+Style/OptionHash:
+  Enabled: false
+Style/OptionalArguments:
+  Enabled: false
+Style/ParallelAssignment:
+  Enabled: false
+Style/ParenthesesAroundCondition:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/PercentQLiterals:
+  Enabled: false
+Style/PerlBackrefs:
+  Enabled: false
+Style/PreferredHashMethods:
+  Enabled: false
+Style/Proc:
+  Enabled: false
+Style/RaiseArgs:
+  Enabled: false
+Style/RedundantBegin:
+  Enabled: false
+Style/RedundantException:
+  Enabled: false
+Style/RedundantFreeze:
+  Enabled: false
+Style/RedundantReturn:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Layout/RescueEnsureAlignment:
+  Enabled: false
+Style/RescueModifier:
+  Enabled: false
+Style/Semicolon:
+  Enabled: false
+Style/Send:
+  Enabled: false
+Style/SignalException:
+  Enabled: false
+Style/SingleLineBlockParams:
+  Enabled: false
+Style/SingleLineMethods:
+  Enabled: false
+Style/SpecialGlobalVars:
+  Enabled: false
+Style/StabbyLambdaParentheses:
+  Enabled: false
 Style/StringLiterals:
   Enabled: false
-
 Style/StringLiteralsInInterpolation:
   Enabled: false
-
-Style/IndentationConsistency:
-  EnforcedStyle: normal
+Style/StringMethods:
+  Enabled: false
+Style/StructInheritance:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/SymbolProc:
+  Enabled: false
+Layout/Tab:
+  Enabled: false
+Style/TernaryParentheses:
+  Enabled: false
+Style/TrailingCommaInArguments:
+  Enabled: false
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+Layout/TrailingWhitespace:
+  Enabled: false
+Style/UnlessElse:
+  Enabled: false
+Style/RedundantCapitalW:
+  Enabled: false
+Style/RedundantInterpolation:
+  Enabled: false
+Style/RedundantPercentQ:
+  Enabled: false
+Style/VariableInterpolation:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Style/WhenThen:
+  Enabled: false
+Style/WhileUntilDo:
+  Enabled: false
+Style/WhileUntilModifier:
+  Enabled: false
+Style/WordArray:
+  Enabled: false
+Style/ZeroLengthPredicate:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For linting, you can use the `.rubocop.yml` in this repository (or your own!).
 You'll need these gems:
 
 ```ruby
-gem "rubocop", "0.48.1"
+gem "rubocop", "0.79.0", require: false
 gem "rubocop-rails"
 ```
 


### PR DESCRIPTION
## Why

Let's update the rules and encourage using Scaffolint.﻿

## What

- [x] Add latest Scaffolint
- [x] Bump rubocop-rails version
- [x] Exclude auto-generated files that are usually not edited by hand
